### PR TITLE
fix: resolve CSRF state mismatch errors

### DIFF
--- a/frontend/public/JS/api.js
+++ b/frontend/public/JS/api.js
@@ -13,7 +13,7 @@ export function getBackendUrl() {
 
   if (typeof window !== "undefined" && window.location.hostname !== "localhost") {
     // In production (e.g., Netlify), assume backend is on Render at standard URL
-    backendUrl = "https://fluxmod.onrender.comm";
+    backendUrl = "https://fluxmod.onrender.com";
   }
 
   // Allow prompt override only in development


### PR DESCRIPTION
- Fix frontend typo: onrender.comm  onrender.com
- Remove quotes from SESSION_SAME_SITE in .env
- Fix FLUXER_AUTHORIZE_URL to use production redirect URI
- Remove trailing slash from FRONTEND_URL
- Ensures session cookies preserved across OAuth flow